### PR TITLE
androidmedia: Read max-input-size from caps

### DIFF
--- a/sys/androidmedia/gstamc.h
+++ b/sys/androidmedia/gstamc.h
@@ -172,7 +172,11 @@ gboolean gst_amc_codec_release_output_buffer (GstAmcCodec * codec, gint index);
 #endif
 
 GstAmcFormat * gst_amc_format_new_audio (const gchar *mime, gint sample_rate, gint channels);
+#ifdef HAVE_ANDROID_MEDIA_HYBRIS
+GstAmcFormat * gst_amc_format_new_video (const gchar *mime, gint width, gint height, gint buffsize);
+#else
 GstAmcFormat * gst_amc_format_new_video (const gchar *mime, gint width, gint height);
+#endif
 void gst_amc_format_free (GstAmcFormat * format);
 
 gchar * gst_amc_format_to_string (GstAmcFormat * format);

--- a/sys/androidmedia/gstamchybris.c
+++ b/sys/androidmedia/gstamchybris.c
@@ -790,7 +790,8 @@ error:
 }
 
 GstAmcFormat *
-gst_amc_format_new_video (const gchar * mime, gint width, gint height)
+gst_amc_format_new_video (const gchar * mime, gint width, gint height,
+    gint buffsize)
 {
   GstAmcFormat *format = NULL;
   gchar *mime_str = NULL;
@@ -807,7 +808,7 @@ gst_amc_format_new_video (const gchar * mime, gint width, gint height)
   format = g_slice_new0 (GstAmcFormat);
 
   format->format =
-      media_format_create_video_format (mime_str, width, height, 0, 0);
+      media_format_create_video_format (mime_str, width, height, 0, buffsize);
   if (format->format == NULL) {
     GST_ERROR ("Failed to create format '%s'", mime);
     goto error;


### PR DESCRIPTION
max-input-size contains the suggested input buffer size that appears in some containers. This size is needed by some decoders to do proper input buffer size calculations.
