### PR TITLE
Play short videos

### DIFF
--- a/sys/androidmedia/gstamcvideodec.h
+++ b/sys/androidmedia/gstamcvideodec.h
@@ -96,6 +96,13 @@ struct _GstAmcVideoDec
   gboolean eos;
 
   GstFlowReturn downstream_flow_ret;
+
+#ifdef HAVE_ANDROID_MEDIA_HYBRIS
+  /* To wait for source caps to be set */
+  GMutex srccaps_lock;
+  GCond srccaps_cond;
+  gboolean srccaps_set;
+#endif
 };
 
 struct _GstAmcVideoDecClass


### PR DESCRIPTION
Very short videos (<2s) were not played some times. This happened due to reception of EOS before having configured the complete pipeline. This commit solves the issue not propagating the EOS event until the
pipeline has been configured. This solves

https://bugs.launchpad.net/media-hub/+bug/1386571
