### PR TITLE
Fix stagnation when obtaining thumbnail

### DIFF
--- a/sys/androidmedia/gstamcvideodechybris.c
+++ b/sys/androidmedia/gstamcvideodechybris.c
@@ -1532,6 +1532,13 @@ flushing:
     GST_DEBUG_OBJECT (self, "Flushing -- pausing video_decoder_src_pad task");
     gst_pad_pause_task (GST_VIDEO_DECODER_SRC_PAD (self));
     self->downstream_flow_ret = GST_FLOW_FLUSHING;
+    g_mutex_lock (&self->drain_lock);
+    if (self->draining) {
+      GST_DEBUG_OBJECT (self, "EOS received while flushing");
+      self->draining = FALSE;
+      g_cond_broadcast (&self->drain_cond);
+    }
+    g_mutex_unlock (&self->drain_lock);
     GST_VIDEO_DECODER_STREAM_UNLOCK (self);
     return;
   }


### PR DESCRIPTION
vs-thumb was never finishing when trying to get a thumbnail for very short videos. This happened because EOS was received but the decoding thread did not signal the 'drained' condition, which is fixed by this commit. Note that in some cases you might not get the thumbnail anyway, but we make sure that vs-thumb stops.

This fixes

https://bugs.launchpad.net/ubuntu/+source/thumbnailer/+bug/1397997
