### PR TITLE
androidmedia: Make seek smoother

### DIFF
--- a/sys/androidmedia/gstamcvideodec.h
+++ b/sys/androidmedia/gstamcvideodec.h
@@ -102,6 +102,7 @@ struct _GstAmcVideoDec
   GMutex srccaps_lock;
   GCond srccaps_cond;
   gboolean srccaps_set;
+  gboolean waiting_segment;
 #endif
 };
 


### PR DESCRIPTION
Seeking with android hybris codecs was not working really well with latest gstreamer versions. This happens due to problems with event propagation with the current amc implementation. This commit improves the situation, although it is not the ideal solution.