### PR TITLE
androidmedia: Remove access unit delimiters

### DIFF
--- a/sys/androidmedia/gstamcvideodec.h
+++ b/sys/androidmedia/gstamcvideodec.h
@@ -103,6 +103,8 @@ struct _GstAmcVideoDec
   GCond srccaps_cond;
   gboolean srccaps_set;
   gboolean waiting_segment;
+
+  const gchar *mime;
 #endif
 };
 


### PR DESCRIPTION
Remove access unit delimiters NALUs from byte stream. These NALUs were causing problems for MTK's decoder and are not really necessary.

This PR is an alternative solution for LP bug #1421750 (see PR #15).