### PR TITLE
androidmedia: Add support for HEVC and VP8/9

### DIFF
--- a/sys/androidmedia/gstamc-constants.h
+++ b/sys/androidmedia/gstamc-constants.h
@@ -101,7 +101,10 @@ enum
   /* From hardware/ti/omap4xxx/domx/omx_core/inc/OMX_TI_IVCommon.h */
   COLOR_TI_FormatYUV420PackedSemiPlanarInterlaced = 0x7f000001,
   COLOR_EXYNOS_FormatNV12Tiled = 0x7fc00002,
-  COLOR_EXYNOS_FormatNV21Linear = 0x7f000011
+  COLOR_EXYNOS_FormatNV21Linear = 0x7f000011,
+  /* MTK formats. FormatYV12 is used by VP8/9. */
+  COLOR_MTK_FormatYV12 = 0x7f000200,
+  COLOR_MTK_FormatBitStream = 0x7f000300
 };
 
 enum

--- a/sys/androidmedia/gstamchybris.c
+++ b/sys/androidmedia/gstamchybris.c
@@ -1186,11 +1186,6 @@ scan_codecs (GstPlugin * plugin)
 
       n_elems = media_codec_list_get_num_profile_levels (i, mime);
       GST_INFO ("Type '%s' has %d supported profile levels", mime, n_elems);
-      if (n_elems == 0) {
-        GST_INFO ("Zero supported profile levels for type '%s'", mime);
-        valid_codec = FALSE;
-        goto next_supported_type;
-      }
       gst_codec_type->n_profile_levels = n_elems;
       gst_codec_type->profile_levels =
           g_malloc0 (sizeof (gst_codec_type->profile_levels[0]) * n_elems);
@@ -1371,7 +1366,8 @@ static const struct
   COLOR_EXYNOS_FormatNV12Tiled, GST_VIDEO_FORMAT_NV12}, {
   COLOR_EXYNOS_FormatNV21Linear, GST_VIDEO_FORMAT_NV21}, {
   256, GST_VIDEO_FORMAT_NV12}, {
-  263, GST_VIDEO_FORMAT_NV12}
+  263, GST_VIDEO_FORMAT_NV12}, {
+  COLOR_MTK_FormatYV12, GST_VIDEO_FORMAT_YV12}
 };
 
 static gboolean


### PR DESCRIPTION
Add capability to decode HEVC and VP8/9 streams in case the android HAL supports them.